### PR TITLE
🐛 FIX: directly access DEFAULT color

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,6 +21,11 @@ module.exports = function ({ e, addUtilities, theme }) {
 					[`.decoration-${e(key)}-${variant}`]: {
 						'text-decoration-color': colors[key][variant],
 					},
+					...(variant === 'DEFAULT' ? {
+						[`.decoration-${e(key)}`]: {
+							'text-decoration-color': colors[key][variant],
+						},
+					} : {} )
 				}),
 				{}
 			),


### PR DESCRIPTION
This allows for

   `decoration-red`

instead of

  `decorations-red-DEFAULT`

The `DEFAULT` accessor has been left in in order to not introduce a breaking change. 